### PR TITLE
Add error stripe marks

### DIFF
--- a/Light_Lite.icls
+++ b/Light_Lite.icls
@@ -293,6 +293,7 @@
       <value>
         <option name="FOREGROUND" value="ea4334" />
         <option name="EFFECT_COLOR" value="ea4334" />
+        <option name="ERROR_STRIPE_COLOR" value="ea4334" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
     </option>
@@ -302,6 +303,7 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="e84135" />
+        <option name="ERROR_STRIPE_COLOR" value="e84135" />
         <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
@@ -329,6 +331,7 @@
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="34a853" />
+        <option name="ERROR_STRIPE_COLOR" value="34a853" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>
@@ -341,6 +344,7 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="fcbc05" />
+        <option name="ERROR_STRIPE_COLOR" value="fcbc05" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -476,6 +480,7 @@
       <value>
         <option name="FOREGROUND" value="ea4334" />
         <option name="EFFECT_COLOR" value="e84135" />
+        <option name="ERROR_STRIPE_COLOR" value="ea4334" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
     </option>
@@ -489,6 +494,7 @@
         <option name="FOREGROUND" value="777777" />
         <option name="FONT_TYPE" value="2" />
         <option name="EFFECT_COLOR" value="333333" />
+        <option name="ERROR_STRIPE_COLOR" value="333333" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -567,6 +573,7 @@
     <option name="TYPO">
       <value>
         <option name="EFFECT_COLOR" value="fcbc05" />
+        <option name="ERROR_STRIPE_COLOR" value="fcbc05" />
         <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
@@ -576,12 +583,14 @@
     <option name="WARNING_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="ea4334" />
+        <option name="ERROR_STRIPE_COLOR" value="ea4334" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="34a853" />
+        <option name="ERROR_STRIPE_COLOR" value="34a853" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>


### PR DESCRIPTION
This change enables the error stripe marks for some of the highlights used in the theme. The color used is the same as the background / underline color used by the theme.

![error-stripe-marks](https://user-images.githubusercontent.com/177329/145180770-9b647ef7-37bf-4abb-a0a3-69e5cbcf2899.png)

I am aware that this change makes the theme less "lite", but I really missed the functionality. Of course the colors could be made a bit lighter to make them less present.
